### PR TITLE
Move domain queries under dnsclient

### DIFF
--- a/lib/cisco_node_utils/command_reference_common.yaml
+++ b/lib/cisco_node_utils/command_reference_common.yaml
@@ -104,8 +104,6 @@ dnsclient:
     config_get_token: '/^ip name-server ([\s\d\.:]+)$/'
     config_set: '<state> ip name-server <ip>'
     default_value: ''
-
-domain_name:
   domain_name:
     # NOTE: This does not account for vrf ip domain-name
     config_get: "show running-config | include 'ip domain-name'"

--- a/lib/cisco_node_utils/domain_name.rb
+++ b/lib/cisco_node_utils/domain_name.rb
@@ -30,7 +30,7 @@ module Cisco
 
     def self.domainnames
       hash = {}
-      domains = config_get('domain_name', 'domain_name')
+      domains = config_get('dnsclient', 'domain_name')
       return hash if domains.nil?
 
       domains.each do |name|
@@ -44,11 +44,11 @@ module Cisco
     end
 
     def create
-      config_set('domain_name', 'domain_name', state: '', name: @name)
+      config_set('dnsclient', 'domain_name', state: '', name: @name)
     end
 
     def destroy
-      config_set('domain_name', 'domain_name', state: 'no', name: @name)
+      config_set('dnsclient', 'domain_name', state: 'no', name: @name)
     end
   end
 end

--- a/tests/test_domain_name.rb
+++ b/tests/test_domain_name.rb
@@ -35,9 +35,6 @@ class TestDomainName < CiscoTestCase
   def no_domainname_test_xyz
     # Turn the feature off for a clean test.
     config('no ip domain-name test.xyz')
-    # Flush the cache since we've modified the device outside of
-    # the node_utils APIs
-    node.cache_flush
   end
 
   # TESTS


### PR DESCRIPTION
The nameserver command reference is under "dnsclient" namespace. The network_dns type will use both name_server and domain_name code, so it makes sense to have it all under one place in the command reference.
